### PR TITLE
removed import of unicode_literals to prevent errors with Python 2.7.…

### DIFF
--- a/stm32_loader.py
+++ b/stm32_loader.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2015 Pavel Kirienko <pavel.kirienko@zubax.com>
 #
 
-from __future__ import division, absolute_import, print_function, unicode_literals
+from __future__ import division, absolute_import, print_function
 
 import sys
 import serial


### PR DESCRIPTION
…5 (as supplied with major Entrrpise Linux distrbutions)

Details about the problem could be found here: http://python-future.org/stdlib_incompatibilities.html

After removing the import, the upgrade works fine now. I hope, it doen't break anything else?
